### PR TITLE
Handle email API failure responses

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -64,5 +64,8 @@ export async function sendPurchaseOrderEmail(
   }
 
   const data = (await response.json()) as PurchaseOrderEmailResponse;
+  if (!data?.success) {
+    throw new Error(data?.message || "Unable to send email.");
+  }
   return data;
 }

--- a/src/pages/PurchaseOrderGenerator.tsx
+++ b/src/pages/PurchaseOrderGenerator.tsx
@@ -145,7 +145,7 @@ export default function PurchaseOrderGenerator() {
       const attachmentBase64 = await blobToBase64(pdfBlob);
       const { grandTotal } = computeTotals(documentData);
 
-      await sendPurchaseOrderEmail({
+      const emailResponse = await sendPurchaseOrderEmail({
         vendorEmail: documentData.vendor.email,
         buyerEmail: documentData.buyer.email || undefined,
         subject: documentData.poNumber
@@ -169,7 +169,9 @@ export default function PurchaseOrderGenerator() {
 
       toast({
         title: "Email sent",
-        description: `Purchase order emailed to ${documentData.vendor.email}.`,
+        description:
+          emailResponse.message ||
+          `Purchase order emailed to ${documentData.vendor.email}.`,
       });
     } catch (error) {
       toast({


### PR DESCRIPTION
## Summary
- throw an error when the email API returns a falsy success flag
- surface the API's response message in the email success toast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f94c9d908333b46715496d4030c7