### PR TITLE
Add support pages and dynamic template routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,14 @@ import PurchaseOrderGenerator from "./pages/PurchaseOrderGenerator";
 import Templates from "./pages/Templates";
 import Pricing from "./pages/Pricing";
 import FAQ from "./pages/FAQ";
+import PurchaseOrderPDF from "./pages/PurchaseOrderPDF";
+import PONumberGenerator from "./pages/PONumberGenerator";
+import PurchaseOrderVsInvoice from "./pages/PurchaseOrderVsInvoice";
+import Contact from "./pages/Contact";
+import Help from "./pages/Help";
+import Privacy from "./pages/Privacy";
+import Terms from "./pages/Terms";
+import TemplateIndustry from "./pages/TemplateIndustry";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -21,9 +29,17 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/purchase-order-generator" element={<PurchaseOrderGenerator />} />
+          <Route path="/purchase-order-pdf" element={<PurchaseOrderPDF />} />
+          <Route path="/po-number-generator" element={<PONumberGenerator />} />
+          <Route path="/purchase-order-vs-invoice" element={<PurchaseOrderVsInvoice />} />
           <Route path="/templates" element={<Templates />} />
+          <Route path="/templates/:industry" element={<TemplateIndustry />} />
           <Route path="/pricing" element={<Pricing />} />
           <Route path="/faq" element={<FAQ />} />
+          <Route path="/contact" element={<Contact />} />
+          <Route path="/help" element={<Help />} />
+          <Route path="/privacy" element={<Privacy />} />
+          <Route path="/terms" element={<Terms />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,85 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+export default function Contact() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main>
+        <section className="py-16">
+          <div className="container-app grid gap-12 lg:grid-cols-[1fr_0.8fr] items-start">
+            <div className="space-y-6">
+              <div className="space-y-4">
+                <p className="text-sm font-medium text-primary">Contact</p>
+                <h1 className="text-4xl font-bold tracking-tight">We're here to help your purchasing team</h1>
+                <p className="text-lg text-muted-foreground">
+                  Reach out for support, onboarding, or custom template requests. Our response time is under 1
+                  business day for all paid plans.
+                </p>
+              </div>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Direct channels</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-muted-foreground">
+                  <div>
+                    <p className="font-semibold text-foreground">Email</p>
+                    <p>support@posuite.app</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-foreground">Phone</p>
+                    <p>+1 (555) 123-6678 • Mon–Fri 9am-6pm ET</p>
+                  </div>
+                  <div>
+                    <p className="font-semibold text-foreground">Enterprise support</p>
+                    <p>Dedicated Slack channel and quarterly reviews for Pro+ plans.</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card className="shadow-medium">
+              <CardHeader>
+                <CardTitle>Send us a message</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="name">Name</Label>
+                  <Input id="name" placeholder="Taylor Evans" />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="email">Work email</Label>
+                  <Input id="email" type="email" placeholder="taylor@company.com" />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="topic">Topic</Label>
+                  <Input id="topic" placeholder="Custom template request" />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="message">Message</Label>
+                  <Textarea id="message" rows={4} placeholder="Tell us about your purchasing workflow..." />
+                </div>
+                <Button className="w-full" type="button">
+                  Submit request
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                  By submitting, you agree to our privacy policy and understand we will contact you about your
+                  request.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,0 +1,90 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Link } from "react-router-dom";
+
+export default function Help() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main>
+        <section className="py-16">
+          <div className="container-app space-y-12">
+            <div className="max-w-3xl space-y-4">
+              <p className="text-sm font-medium text-primary">Help Center</p>
+              <h1 className="text-4xl font-bold tracking-tight">Get answers fast</h1>
+              <p className="text-lg text-muted-foreground">
+                Browse setup guides, troubleshooting steps, and procurement best practices. Still stuck? Reach
+                out and our team will jump on a call within one business day.
+              </p>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Quick start</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                  <p>Create your first purchase order in under five minutes.</p>
+                  <p>Invite teammates and manage approval workflows.</p>
+                  <Button asChild variant="outline">
+                    <Link to="/purchase-order-generator">Launch generator</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Accounts payable checklist</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                  <p>Match vendor invoices to outstanding purchase orders.</p>
+                  <p>Track receipts and delivery confirmations.</p>
+                  <Button asChild>
+                    <Link to="/purchase-order-vs-invoice">Compare PO vs invoice</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Top questions</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Accordion type="single" collapsible className="w-full">
+                  <AccordionItem value="export">
+                    <AccordionTrigger>How do I export documents?</AccordionTrigger>
+                    <AccordionContent>
+                      Head to the generator, fill in your details, then choose PDF or DOCX export from the preview
+                      pane. The file downloads instantly with your numbering sequence applied.
+                    </AccordionContent>
+                  </AccordionItem>
+                  <AccordionItem value="numbering">
+                    <AccordionTrigger>Can I share numbering presets with my team?</AccordionTrigger>
+                    <AccordionContent>
+                      Yes. Create a preset on the PO Numbering page, then toggle "Team access". Everyone on your
+                      workspace can apply it from the generator sidebar.
+                    </AccordionContent>
+                  </AccordionItem>
+                  <AccordionItem value="security">
+                    <AccordionTrigger>How is my data secured?</AccordionTrigger>
+                    <AccordionContent>
+                      We encrypt all data in transit and at rest. Enterprise plans offer regional hosting and
+                      single sign-on with audit logging.
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/PONumberGenerator.tsx
+++ b/src/pages/PONumberGenerator.tsx
@@ -1,0 +1,94 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Link } from "react-router-dom";
+
+function NumberingBadge({ prefix, nextNumber }: { prefix: string; nextNumber: number }) {
+  return (
+    <div className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-sm font-medium text-primary">
+      {prefix}
+      {String(nextNumber).padStart(4, "0")}
+    </div>
+  );
+}
+
+export default function PONumberGenerator() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main>
+        <section className="py-16">
+          <div className="container-app space-y-12">
+            <div className="max-w-3xl space-y-4">
+              <p className="text-sm font-medium text-primary">Auto-numbering</p>
+              <h1 className="text-4xl font-bold tracking-tight">Generate purchase order numbers that scale</h1>
+              <p className="text-lg text-muted-foreground">
+                Establish consistent numbering sequences for every business unit. Configure prefixes, digit
+                padding, and annual resets—then apply the sequence directly in the PO generator.
+              </p>
+              <div className="flex items-center gap-3">
+                <NumberingBadge prefix="PO-" nextNumber={128} />
+                <NumberingBadge prefix="MRO-" nextNumber={42} />
+                <NumberingBadge prefix="EU-" nextNumber={5801} />
+              </div>
+            </div>
+
+            <div className="grid gap-8 lg:grid-cols-2">
+              <Card className="h-full">
+                <CardHeader>
+                  <CardTitle>Create a numbering preset</CardTitle>
+                </CardHeader>
+                <CardContent className="grid gap-4">
+                  <div className="grid gap-2">
+                    <Label htmlFor="prefix">Prefix</Label>
+                    <Input id="prefix" placeholder="PO-" />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="padding">Digits</Label>
+                    <Input id="padding" type="number" min={3} placeholder="4" />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="reset">Reset cadence</Label>
+                    <Input id="reset" placeholder="Annually (Jan 1)" />
+                  </div>
+                  <Button asChild>
+                    <Link to="/purchase-order-generator">Apply in generator</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+
+              <Card className="h-full border-dashed">
+                <CardHeader>
+                  <CardTitle>Recommended sequences</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4 text-sm text-muted-foreground">
+                  <div>
+                    <h3 className="font-semibold text-foreground">Operations</h3>
+                    <p>Use prefixes by location (e.g., NY-PO-) and reset annually to simplify auditing.</p>
+                  </div>
+                  <Separator />
+                  <div>
+                    <h3 className="font-semibold text-foreground">Maintenance &amp; MRO</h3>
+                    <p>Short prefixes (MRO-) with 5 digits make work orders easy to reference in the field.</p>
+                  </div>
+                  <Separator />
+                  <div>
+                    <h3 className="font-semibold text-foreground">Projects</h3>
+                    <p>Include the project code (PRJ-204-) to tie POs back to budgets and reporting.</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,63 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+
+export default function Privacy() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main>
+        <section className="py-16">
+          <div className="container-app max-w-3xl space-y-8">
+            <div className="space-y-4">
+              <p className="text-sm font-medium text-primary">Privacy Policy</p>
+              <h1 className="text-4xl font-bold tracking-tight">Your data, protected and transparent</h1>
+              <p className="text-lg text-muted-foreground">
+                We built PO Suite with data protection in mind. Review how we collect, store, and process
+                information to power your purchasing workflows.
+              </p>
+            </div>
+
+            <Accordion type="single" collapsible className="w-full space-y-2">
+              <AccordionItem value="collection" className="border rounded-lg px-4">
+                <AccordionTrigger>Information we collect</AccordionTrigger>
+                <AccordionContent className="text-sm text-muted-foreground">
+                  We gather account details (name, work email), document metadata, and usage analytics to improve
+                  the product. We do not access the contents of your generated purchase orders without consent.
+                </AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="storage" className="border rounded-lg px-4">
+                <AccordionTrigger>Storage &amp; retention</AccordionTrigger>
+                <AccordionContent className="text-sm text-muted-foreground">
+                  Data is stored in SOC 2-compliant infrastructure located in the US and EU. Purchase orders are
+                  retained for as long as your workspace is active or until you delete them.
+                </AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="rights" className="border rounded-lg px-4">
+                <AccordionTrigger>Your rights</AccordionTrigger>
+                <AccordionContent className="text-sm text-muted-foreground">
+                  You can request access, correction, or deletion of your data at any time by emailing
+                  privacy@posuite.app. We respond within 30 days and support GDPR/CCPA requests.
+                </AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="security" className="border rounded-lg px-4">
+                <AccordionTrigger>Security commitments</AccordionTrigger>
+                <AccordionContent className="text-sm text-muted-foreground">
+                  We encrypt data in transit and at rest, run annual penetration tests, and monitor for abnormal
+                  access. Enterprise customers may enable SSO and custom data retention policies.
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+
+            <p className="text-sm text-muted-foreground">
+              Questions about privacy? Contact privacy@posuite.app or view our security overview in the Help Center.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/PurchaseOrderPDF.tsx
+++ b/src/pages/PurchaseOrderPDF.tsx
@@ -1,0 +1,105 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Link } from "react-router-dom";
+
+export default function PurchaseOrderPDF() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main>
+        <section className="py-16">
+          <div className="container-app grid gap-12 lg:grid-cols-[1.1fr_0.9fr] items-start">
+            <div>
+              <p className="text-sm font-medium text-primary">PDF Export Guide</p>
+              <h1 className="mt-2 text-4xl font-bold tracking-tight">Export purchase orders as polished PDFs</h1>
+              <p className="mt-4 text-lg text-muted-foreground">
+                Use this quick worksheet to prep your document and learn best practices for exporting from
+                the generator. Share compliant, branded PDFs with vendors in seconds.
+              </p>
+
+              <div className="mt-8 grid gap-6">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Quick export checklist</CardTitle>
+                  </CardHeader>
+                  <CardContent className="grid gap-4">
+                    <div className="grid gap-2">
+                      <Label htmlFor="po-number">PO Number</Label>
+                      <Input id="po-number" placeholder="PO-2024-1042" />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor="vendor">Vendor name</Label>
+                      <Input id="vendor" placeholder="Acme Supplies" />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor="notes">Internal notes</Label>
+                      <Textarea id="notes" placeholder="Remind vendor to confirm delivery date." rows={3} />
+                    </div>
+                    <Button asChild>
+                      <Link to="/purchase-order-generator">Open generator</Link>
+                    </Button>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Export pro tips</CardTitle>
+                  </CardHeader>
+                  <CardContent className="grid gap-3 text-sm text-muted-foreground">
+                    <p>
+                      • Fill in all buyer and vendor contact details before exporting to avoid manual edits.
+                    </p>
+                    <p>
+                      • Use the logo uploader for brand consistency, then download as PDF or DOCX depending on
+                      vendor preference.
+                    </p>
+                    <p>
+                      • Enable auto-numbering in Pro plans to keep PDF filenames and document sequences aligned.
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+
+            <Card className="border-primary/20 bg-primary/5">
+              <CardHeader>
+                <CardTitle className="text-xl">FAQ</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-6 text-sm">
+                <div>
+                  <h3 className="font-semibold text-foreground">Can I download without watermarks?</h3>
+                  <p className="text-muted-foreground">
+                    Yes—upgrade to the Pro plan to remove the default watermark and unlock custom branding.
+                  </p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-foreground">Do vendors need special software?</h3>
+                  <p className="text-muted-foreground">
+                    No. PDFs generated here are standards compliant and open in any modern viewer or browser.
+                  </p>
+                </div>
+                <div>
+                  <h3 className="font-semibold text-foreground">Where are files stored?</h3>
+                  <p className="text-muted-foreground">
+                    Exported PDFs are generated in-browser. Save locally or to your document management system.
+                  </p>
+                </div>
+                <Button asChild className="w-full">
+                  <Link to="/purchase-order-generator">Create my PO</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/PurchaseOrderVsInvoice.tsx
+++ b/src/pages/PurchaseOrderVsInvoice.tsx
@@ -1,0 +1,115 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Link } from "react-router-dom";
+
+const comparison = [
+  {
+    label: "Purpose",
+    purchaseOrder: "Formal request from buyer to vendor, locks in pricing and delivery expectations.",
+    invoice: "Bill issued by vendor after goods/services are delivered, requesting payment.",
+  },
+  {
+    label: "When it's sent",
+    purchaseOrder: "Before fulfillment, once internal approvals are complete.",
+    invoice: "After fulfillment, once quantities and totals are confirmed.",
+  },
+  {
+    label: "Key fields",
+    purchaseOrder: "PO number, buyer/vendor info, itemized list, delivery terms, approval signature.",
+    invoice: "Invoice number, PO reference, payment terms, remittance details, tax breakdown.",
+  },
+  {
+    label: "Who issues it",
+    purchaseOrder: "Buyer or procurement team.",
+    invoice: "Vendor or accounts receivable.",
+  },
+  {
+    label: "Legal status",
+    purchaseOrder: "Becomes legally binding once accepted by vendor.",
+    invoice: "Records the amount owed and can serve as evidence of debt.",
+  },
+];
+
+export default function PurchaseOrderVsInvoice() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main>
+        <section className="py-16">
+          <div className="container-app space-y-12">
+            <div className="max-w-3xl space-y-4">
+              <p className="text-sm font-medium text-primary">PO vs Invoice</p>
+              <h1 className="text-4xl font-bold tracking-tight">Understand the difference between purchase orders and invoices</h1>
+              <p className="text-lg text-muted-foreground">
+                Purchase orders initiate a commitment, while invoices confirm delivery and request payment. Use this
+                guide to align procurement and accounting teams on how each document flows through your process.
+              </p>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Side-by-side comparison</CardTitle>
+              </CardHeader>
+              <CardContent className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-48">Topic</TableHead>
+                      <TableHead>Purchase Order</TableHead>
+                      <TableHead>Invoice</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {comparison.map((row) => (
+                      <TableRow key={row.label}>
+                        <TableCell className="font-medium">{row.label}</TableCell>
+                        <TableCell>{row.purchaseOrder}</TableCell>
+                        <TableCell>{row.invoice}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle>When to create a PO</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                  <p>Confirm scope and pricing with the vendor before work begins.</p>
+                  <p>Route for approval in procurement or finance based on spend thresholds.</p>
+                  <p>Send the PO to the vendor and attach it to your ERP or purchasing system.</p>
+                  <Button asChild variant="outline">
+                    <Link to="/purchase-order-generator">Generate a PO</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>When to request an invoice</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                  <p>Ensure goods have arrived or services are complete and match the PO.</p>
+                  <p>Have the vendor reference the original PO number to streamline matching.</p>
+                  <p>Verify totals, taxes, and payment terms before sending to accounts payable.</p>
+                  <Button asChild>
+                    <Link to="/help">View AP checklist</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/TemplateIndustry.tsx
+++ b/src/pages/TemplateIndustry.tsx
@@ -1,0 +1,163 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Link, useParams } from "react-router-dom";
+import { Building, Code, Store } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+const industries: Record<
+  string,
+  {
+    name: string;
+    description: string;
+    highlights: string[];
+    compliance: string[];
+    icon: LucideIcon;
+  }
+> = {
+  construction: {
+    name: "Construction",
+    description: "Track materials, subcontractors, and change orders with job codes and retention terms.",
+    highlights: [
+      "Prefill site address and foreman contact",
+      "Include lien waiver clauses and insurance requirements",
+      "Budget tracking fields for labor vs. materials",
+    ],
+    compliance: [
+      "Supports AIA billing references",
+      "Stores COI renewal reminders",
+      "Retains records for 7+ years",
+    ],
+    icon: Building,
+  },
+  technology: {
+    name: "Technology",
+    description: "Capture SaaS renewals, hardware SKUs, and SOC/ISO compliance attestation in one template.",
+    highlights: [
+      "Track license counts and renewal dates",
+      "Reference security questionnaires and data residency",
+      "Flag auto-renew clauses for approvals",
+    ],
+    compliance: [
+      "GDPR and SOC 2 reminders",
+      "Vendor risk owner assignment",
+      "Attachment slots for DPAs",
+    ],
+    icon: Code,
+  },
+  retail: {
+    name: "Retail",
+    description: "Manage seasonal inventory, merchandising displays, and vendor chargebacks.",
+    highlights: [
+      "Segment by store, region, or channel",
+      "Include UPC/SKU imports for bulk items",
+      "Track promotions and co-op marketing fees",
+    ],
+    compliance: [
+      "Integrates with POS and ERP exports",
+      "Supports GS1 barcode references",
+      "Keeps audit log for vendor agreements",
+    ],
+    icon: Store,
+  },
+};
+
+const defaultIndustry = {
+  name: "Purchase Order Template",
+  description: "A flexible template ready for any procurement workflow. Customize fields, numbering, and export formats.",
+  highlights: [
+    "Add buyer and vendor details with one click",
+    "Customize currencies, taxes, and payment terms",
+    "Invite teammates to review and approve in real time",
+  ],
+  compliance: [
+    "SOC 2 Type II infrastructure",
+    "GDPR and CCPA compliant",
+    "Regional data hosting options",
+  ],
+  icon: Building,
+};
+
+export default function TemplateIndustry() {
+  const { industry = "" } = useParams();
+  const info = industries[industry ?? ""] ?? defaultIndustry;
+  const Icon = info.icon;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main>
+        <section className="py-16">
+          <div className="container-app space-y-12">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-4 max-w-3xl">
+                <Badge variant="secondary" className="w-fit text-primary">
+                  Industry template
+                </Badge>
+                <h1 className="text-4xl font-bold tracking-tight flex items-center gap-3">
+                  <span className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                    <Icon className="h-6 w-6" />
+                  </span>
+                  {info.name}
+                </h1>
+                <p className="text-lg text-muted-foreground">{info.description}</p>
+              </div>
+              <Button asChild size="lg">
+                <Link to={`/purchase-order-generator?template=${industry ?? "custom"}`}>
+                  Use this template
+                </Link>
+              </Button>
+            </div>
+
+            <div className="grid gap-8 md:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle>Recommended fields</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                  {info.highlights.map((item) => (
+                    <div key={item} className="rounded-lg border border-dashed p-3">
+                      {item}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle>Compliance notes</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                  {info.compliance.map((item) => (
+                    <div key={item} className="rounded-lg bg-muted/50 p-3">
+                      {item}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Implementation tips</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-muted-foreground">
+                <p>Save this template as a preset in the generator to reuse across teams.</p>
+                <Separator />
+                <p>Connect exports to your ERP or accounting tool via Zapier, Make, or our API.</p>
+                <Separator />
+                <p>Need a branded PDF or custom approval workflow? Our team can help tailor it.</p>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,63 @@
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+
+export default function Terms() {
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+
+      <main>
+        <section className="py-16">
+          <div className="container-app max-w-3xl space-y-8">
+            <div className="space-y-4">
+              <p className="text-sm font-medium text-primary">Terms of Service</p>
+              <h1 className="text-4xl font-bold tracking-tight">Understand your agreement with PO Suite</h1>
+              <p className="text-lg text-muted-foreground">
+                Review the legal terms that govern your use of the purchase order generator, templates, and
+                integrations.
+              </p>
+            </div>
+
+            <Accordion type="single" collapsible className="w-full space-y-2">
+              <AccordionItem value="eligibility" className="border rounded-lg px-4">
+                <AccordionTrigger>Account eligibility</AccordionTrigger>
+                <AccordionContent className="text-sm text-muted-foreground">
+                  You must be 18 or older and authorized to represent your organization. Accounts are limited to one
+                  workspace per legal entity unless otherwise approved.
+                </AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="usage" className="border rounded-lg px-4">
+                <AccordionTrigger>Permitted use</AccordionTrigger>
+                <AccordionContent className="text-sm text-muted-foreground">
+                  Use the platform to create, manage, and share purchasing documents. Reverse engineering or
+                  reselling our services is prohibited without written consent.
+                </AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="billing" className="border rounded-lg px-4">
+                <AccordionTrigger>Billing &amp; renewals</AccordionTrigger>
+                <AccordionContent className="text-sm text-muted-foreground">
+                  Subscriptions renew monthly or annually depending on your plan. Cancel anytime before renewal to
+                  avoid future charges. Refunds are handled on a case-by-case basis.
+                </AccordionContent>
+              </AccordionItem>
+              <AccordionItem value="liability" className="border rounded-lg px-4">
+                <AccordionTrigger>Limitation of liability</AccordionTrigger>
+                <AccordionContent className="text-sm text-muted-foreground">
+                  PO Suite is provided "as-is". We are not liable for indirect damages or lost profits. Our total
+                  liability is capped at fees paid in the prior 12 months.
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+
+            <p className="text-sm text-muted-foreground">
+              Need a signed MSA or DPA? Email legal@posuite.app and we will share enterprise-ready agreements.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add support pages for PDF exports, numbering, PO vs invoice, contact, help, privacy, and terms with shadcn layout blocks
- register new routes in the router so footer and template links resolve to the appropriate pages
- introduce a dynamic industry template page that surfaces tailored guidance and CTA back to the generator

## Testing
- npm run lint *(fails: existing lint violations in shared ui components outside this change)*

## Manual QA
- [ ] Navigate to `/purchase-order-pdf` and confirm the export checklist and FAQ render
- [ ] Navigate to `/po-number-generator` and confirm numbering presets card renders
- [ ] Navigate to `/purchase-order-vs-invoice` and confirm comparison table loads
- [ ] Navigate to `/contact` and `/help` and confirm support content renders
- [ ] Navigate to `/privacy` and `/terms` and confirm policy accordions expand
- [ ] Navigate to `/templates/construction` to confirm industry-specific template guidance appears

------
https://chatgpt.com/codex/tasks/task_e_68d7f042fa108333acd4775111af93fa