### PR TITLE
Improve PDF escaping and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-test
 dist-ssr
 *.local
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "build:test": "tsc -p tsconfig.test.json",
+    "test": "npm run build:test && node --test dist-test/tests/exporters.test.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/src/components/generator/DocumentForm.tsx
+++ b/src/components/generator/DocumentForm.tsx
@@ -7,36 +7,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Plus, Trash2, Shuffle } from "lucide-react";
+import type { DocumentData, LineItem } from "../../types/purchase-order";
 
-export interface LineItem {
-  id: string;
-  description: string;
-  quantity: number;
-  unitPrice: number;
-  total: number;
-}
-
-export interface DocumentData {
-  buyer: {
-    name: string;
-    address: string;
-    email: string;
-    phone: string;
-    vatNumber: string;
-  };
-  vendor: {
-    name: string;
-    address: string;
-    email: string;
-    phone: string;
-    vatNumber: string;
-  };
-  lineItems: LineItem[];
-  currency: string;
-  taxRate: number;
-  notes: string;
-  poNumber: string;
-}
+export type { DocumentData, LineItem } from "../../types/purchase-order";
 
 interface DocumentFormProps {
   data: DocumentData;

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,4 +1,4 @@
-import type { DocumentData } from "@/components/generator/DocumentForm";
+import type { DocumentData } from "../types/purchase-order";
 import { supabase } from "@/integrations/supabase/client";
 
 export interface EmailAttachment {

--- a/src/lib/exporters.ts
+++ b/src/lib/exporters.ts
@@ -1,4 +1,4 @@
-import type { DocumentData } from "@/components/generator/DocumentForm";
+import type { DocumentData } from "../types/purchase-order";
 
 const WATERMARK_TEXT = "Generated with Docu Builder Kit · Free Plan";
 const PDF_TITLE = "Purchase Order";
@@ -11,8 +11,16 @@ function formatCurrency(value: number, currency: string) {
   }).format(value);
 }
 
-function escapePdf(text: string) {
-  return text.replace(/\\/g, "\\\\").replace(/\\(/g, "\\(").replace(/\\)/g, "\\)");
+export function escapePdf(text: string) {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
+    .replace(/\f/g, "\\f")
+    .replace(/\u0008/g, "\\b");
 }
 
 function xmlEscape(text: string) {

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,4 +1,4 @@
-import { DocumentData } from "@/components/generator/DocumentForm";
+import type { DocumentData } from "../types/purchase-order";
 
 export const documentTemplates: Record<string, DocumentData> = {
   construction: {

--- a/src/types/purchase-order.ts
+++ b/src/types/purchase-order.ts
@@ -1,0 +1,25 @@
+export interface LineItem {
+  id: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  total: number;
+}
+
+export interface Party {
+  name: string;
+  address: string;
+  email: string;
+  phone: string;
+  vatNumber: string;
+}
+
+export interface DocumentData {
+  buyer: Party;
+  vendor: Party;
+  lineItems: LineItem[];
+  currency: string;
+  taxRate: number;
+  notes: string;
+  poNumber: string;
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist-test",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/lib/exporters.ts", "src/types/purchase-order.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist", "dist-test"]
+}


### PR DESCRIPTION
## Summary
- update the PDF escaping helper to cover parentheses and other control characters and export it for reuse
- add shared purchase-order data types and adjust imports that consume them
- introduce a Node-based test suite for the PDF exporter and configure a TypeScript build for tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8044632988333a5ca34dc56f1f317