### PR TITLE
Fix PDF trailer newline handling

### DIFF
--- a/src/lib/exporters.ts
+++ b/src/lib/exporters.ts
@@ -180,7 +180,15 @@ export async function generatePurchaseOrderPDF(data: DocumentData) {
     xref += `${offsets[i].toString().padStart(10, "0")} 00000 n \\n`;
   }
 
-  const trailer = `trailer\\n<< /Size ${objects.length + 1} /Root ${catalogObj} 0 R >>\\nstartxref\\n${xrefOffset}\\n%%EOF`;
+  const trailerLines = [
+    "trailer",
+    `<< /Size ${objects.length + 1} /Root ${catalogObj} 0 R >>`,
+    "startxref",
+    `${xrefOffset}`,
+    "%%EOF",
+    "",
+  ];
+  const trailer = trailerLines.join("\n");
   parts.push(xref);
   parts.push(trailer);
 

--- a/tests/exporters.test.ts
+++ b/tests/exporters.test.ts
@@ -51,6 +51,10 @@ test("generatePurchaseOrderPDF produces an openable PDF with escaped content", a
     pdfContent.includes("PO Number: PO-\\(123\\)"),
     "Escaped parentheses should be present in PDF stream",
   );
+  assert.ok(
+    pdfContent.endsWith("\n%%EOF\n"),
+    "PDF should terminate with a newline after the EOF marker",
+  );
 });
 
 test("calculateTotals preserves fractional quantities in grand total", () => {


### PR DESCRIPTION
## Summary
- build the PDF trailer using newline-separated lines so the document terminates with an actual line feed after %%EOF
- add a regression test that verifies the generated purchase order PDF buffer ends with the expected \n%%EOF\n suffix

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcdf641bbc8333a98806c3dcf795e2